### PR TITLE
Add demo detection for Turbo and Maniaplanet

### DIFF
--- a/Main.as
+++ b/Main.as
@@ -40,7 +40,7 @@ void Main()
 
 void RenderMenu()
 {
-	bool canOpenAdvancedEditor;
+	bool canOpenAdvancedEditor = false;
 #if NEXT
 	canOpenAdvancedEditor = Permissions::OpenAdvancedMapEditor();
 #elif MP4

--- a/Main.as
+++ b/Main.as
@@ -40,7 +40,14 @@ void Main()
 
 void RenderMenu()
 {
-	bool canOpenAdvancedEditor = Permissions::OpenAdvancedMapEditor();
+	bool canOpenAdvancedEditor;
+#if NEXT
+	canOpenAdvancedEditor = Permissions::OpenAdvancedMapEditor();
+#elif MP4
+	canOpenAdvancedEditor = GetDemoManiaPlanet();
+#elif TURBO
+	canOpenAdvancedEditor = GetDemoTurbo();
+#endif
 	if (UI::MenuItem("\\$cf9" + Icons::Map + "\\$z Create a new map", "", g_createUI.m_visible, canOpenAdvancedEditor) && !g_createUI.m_visible) {
 		g_createUI.m_visible = !g_createUI.m_visible;
 	}
@@ -50,3 +57,19 @@ void RenderInterface()
 {
 	g_createUI.Render();
 }
+
+#if MP4
+bool GetDemoManiaPlanet()
+{
+	auto app = cast<CGameManiaPlanet>(GetApp());
+	return app.Stations.Length == 0;
+}
+#endif
+
+#if TURBO
+bool GetDemoTurbo()
+{
+	auto app = cast<CGameManiaPlanet>(GetApp());
+	return app.ManiaPlanetScriptAPI.TmTurbo_IsDemo;
+}
+#endif

--- a/Main.as
+++ b/Main.as
@@ -62,7 +62,7 @@ void RenderInterface()
 bool GetDemoManiaPlanet()
 {
 	auto app = cast<CGameManiaPlanet>(GetApp());
-	return app.Stations.Length == 0;
+	return app.Stations.Length != 0;
 }
 #endif
 
@@ -70,6 +70,6 @@ bool GetDemoManiaPlanet()
 bool GetDemoTurbo()
 {
 	auto app = cast<CGameManiaPlanet>(GetApp());
-	return app.ManiaPlanetScriptAPI.TmTurbo_IsDemo;
+	return !app.ManiaPlanetScriptAPI.TmTurbo_IsDemo;
 }
 #endif


### PR DESCRIPTION
Maniaplanet and Turbo demo users (aka people who didn't buy the game yet) have been able to abuse the Big Decors plugin to get access to the map editor.

I would also suggest adding this limitation to the Permissions API so that existing plugins would work perfectly with MP4/Turbo, alongside adding it to the Openplanet Developer Mode with a popup on startup that says "Limited Openplanet Functionality", just like in TM2020's Starter and Standard Access levels.